### PR TITLE
7-adjustment-of-the-all-resources-button-styling

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -143,3 +143,10 @@
     color: #EF7D00 !important;
 }
 
+.resource-editor .btn {
+    width: 100%;
+    margin: 0;
+    background-color: var(--primary);
+    font-size: inherit;
+}
+

--- a/ckanext/zarr/templates/package/new_resource_not_draft.html
+++ b/ckanext/zarr/templates/package/new_resource_not_draft.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+
+{% block maintag %}<div class="main resource-editor">{% endblock %}


### PR DESCRIPTION
## Description

The 'All resources' button in the resource editor is not positioned very well, I made this PR in an attempt to fix it.

Closes https://github.com/fjelltopp/zarr-ckan/issues/136

Default:
![image](https://github.com/user-attachments/assets/62d441e4-7237-44ea-808a-c12e7a7b09be)

Updated:
![image](https://github.com/user-attachments/assets/10319754-8d74-4cf9-9bc0-1c43c2af4dfb)


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
