### PR TITLE
13-Resource type as topic

### DIFF
--- a/ckanext/zarr/helpers.py
+++ b/ckanext/zarr/helpers.py
@@ -126,7 +126,7 @@ def month_formatter(month):
 def get_datasets_by_resource_type(resource_type):
     params = {
         'q': f'resource_type:"{resource_type}"',
-        'sort': 'metadata_modified desc'
+        'sort': 'score desc,metadata_modified desc'
     }
     base_url = toolkit.url_for('dataset.search')
     query_string = urllib.parse.urlencode(params)

--- a/ckanext/zarr/helpers.py
+++ b/ckanext/zarr/helpers.py
@@ -4,6 +4,7 @@ from ckan.common import c, request, is_flask_request, g
 from datetime import datetime, timedelta
 from ckan.plugins import toolkit
 import html
+import urllib.parse
 
 
 def get_user_obj(field=""):
@@ -120,3 +121,23 @@ def lower_formatter(input):
 
 def month_formatter(month):
     return datetime.strptime(month, "%Y-%m").strftime("%b %Y")
+
+
+def get_datasets_by_resource_type(resource_type):
+    params = {
+        'q': f'resource_type:"{resource_type}"',
+        'sort': 'metadata_modified desc'
+    }
+    base_url = toolkit.url_for('dataset.search')
+    query_string = urllib.parse.urlencode(params)
+    return f"{base_url}?{query_string}"
+
+
+def get_schema_field_choices(schema_type, schema_field_name):
+    schema = toolkit.get_action('scheming_dataset_schema_show')(
+        data_dict={'type': schema_type}
+    )
+    for field in schema.get('dataset_fields', []):
+        if field.get('field_name') == schema_field_name:
+            return [{'title': choice['label'], 'url': get_datasets_by_resource_type(choice['value'])} for choice in field.get('choices', [])]
+    return []

--- a/ckanext/zarr/plugin.py
+++ b/ckanext/zarr/plugin.py
@@ -33,7 +33,8 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
             'get_all_groups': zarr_helpers.get_all_groups,
             'get_user_from_id': zarr_helpers.get_user_from_id,
             'get_user_obj': zarr_helpers.get_user_obj,
-            'month_formatter': zarr_helpers.month_formatter
+            'month_formatter': zarr_helpers.month_formatter,
+            'get_schema_field_choices': zarr_helpers.get_schema_field_choices
         }
 
     # IConfigurer

--- a/ckanext/zarr/templates/home/layout1.html
+++ b/ckanext/zarr/templates/home/layout1.html
@@ -3,16 +3,7 @@
 {% block title %}{{ _('Featured data') }}{% endblock %}
 {% block first_row_title %}{{ _('Featured datasets') }}{% endblock %}
 {% block second_row_title %}{{ _('Recently updated datasets') }}{% endblock %}
-{% set topics = [
-    {"title": "Topic 1", "url": "#" },
-    {"title": "Topic 2", "url": "#" },
-    {"title": "Topic 3", "url": "#" },
-    {"title": "Topic 4", "url": "#" },
-    {"title": "Topic 5", "url": "#" },
-    {"title": "Topic 6", "url": "#" },
-    {"title": "Topic 7", "url": "#" },
-    {"title": "Topic 8", "url": "#" },
-] %}
+{% set topics = h.get_schema_field_choices('dataset', 'resource_type') %}
 
 {% block groups %}
 <div class="topics-background">


### PR DESCRIPTION
## Description
This small changes uses the resources topic from dublin core schema as topics in homepage as a temporary solution.

![image](https://github.com/user-attachments/assets/1a166733-4f56-4ab8-8801-43976b4a702c)
![image](https://github.com/user-attachments/assets/45096161-54aa-45f4-87c0-54dde635b1bc)


Closes https://github.com/fjelltopp/zarr-ckan/issues/144

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
