### PR TITLE
feat: add a placeholder video to the homepage

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -31,6 +31,15 @@
 
 }
 
+.homepage .hero .insights figure {
+    margin-top: 20px;
+}
+
+.homepage .hero .insights figcaption {
+    margin-left: 15px;
+    width: 500px;
+}
+
 .promoted-background {
     background-color: #13240F;
 }

--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -33,11 +33,17 @@
 
 .homepage .hero .insights figure {
     margin-top: 20px;
+    width: 560px;
+    max-width: 100%;
+}
+
+.homepage .hero .insights figure iframe {
+    width: 100%;
 }
 
 .homepage .hero .insights figcaption {
     margin-left: 15px;
-    width: 500px;
+    width: 90%;
 }
 
 .promoted-background {

--- a/ckanext/zarr/assets/css/zarr_palette.css
+++ b/ckanext/zarr/assets/css/zarr_palette.css
@@ -29,9 +29,6 @@
     /* promoted background color */
     --promoted-background-color: #13240F;
     /* insights */
-    --show-insights-title-display: none;  /* set to block to show */
-    --upper-container-display: none;  /* set to flex to show */
-    --upper-container-display-mobile: none; /* set to block to show */
     --lower-container-display: flex;  /* set to flex to show */
     --after-insights-min-height: 400px;
     /* masthead */

--- a/ckanext/zarr/templates/home/snippets/insights.html
+++ b/ckanext/zarr/templates/home/snippets/insights.html
@@ -1,7 +1,16 @@
 {% ckan_extends %}
 
-{% block bottom_container_left_label %}{{ _('Section title') }}{% endblock %}
+{% block top_container_title %}{{ _('Find out more about the repository') }}{% endblock %}
 
-{% block bottom_container_left_content_label %}{{ _('Indicators') }}{% endblock %}
+{% block top_container %}
+    <div class="row insight-row insights-upper-item">
+        <div class="d-flex justify-content-center">
+            <figure class="figure">
+                <iframe class="figure-img" width="560" height="315" src="https://www.youtube.com/embed/BzhjEphkQzQ?si=tLJ2xcxEjxIQvOIA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                <figcaption class="figure-caption">[Coming Soon] Watch this video to find out more about the Zambia Research and Evaluation Repository</figcaption>
+            </figure>
+        </div>
+    </div>
+{% endblock %}
 
-{% block bottom_container_right_label %}Data hub stats{% endblock %}
+{% block bottom_container %}{% endblock bottom_container %}

--- a/ckanext/zarr/templates/home/snippets/insights.html
+++ b/ckanext/zarr/templates/home/snippets/insights.html
@@ -7,7 +7,7 @@
         <div class="d-flex justify-content-center">
             <figure class="figure">
                 <iframe class="figure-img" width="560" height="315" src="https://www.youtube.com/embed/BzhjEphkQzQ?si=tLJ2xcxEjxIQvOIA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-                <figcaption class="figure-caption">[Coming Soon] Watch this video to find out more about the Zambia Research and Evaluation Repository</figcaption>
+                <figcaption class="figure-caption">{{ _('[Coming Soon] Watch this video to find out more about the Zambia Research and Evaluation Repository') }}</figcaption>
             </figure>
         </div>
     </div>


### PR DESCRIPTION
## Description

Uses the insights block to add a video. The idea is that the client will replace this with an introduction to the repository, ideally featuring the minister or somebody high up.

closes fjelltopp/zarr-ckan#146

On laptop:
![image](https://github.com/user-attachments/assets/87dc01d2-4651-4a9d-95fd-096ccbe3079d)

On phone:
![image](https://github.com/user-attachments/assets/224c4ab2-63a7-4995-afb9-995acff84fb1)

## Internationalisation and Localisation

Strings are i18n friendly but not translated. This is probably fine for this client.

## Checklist

- [x] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
