### PR TITLE
fix: give webassets unique names

### DIFF
--- a/ckanext/zarr/assets/webassets.yml
+++ b/ckanext/zarr/assets/webassets.yml
@@ -1,11 +1,9 @@
 zarr-theme:
-  filter: cssrewrite
   output: zarr/%(version)s-zarr.css
   contents:
     - css/zarr.css
 
 zarr-theme-palette:
-  filter: cssrewrite
   output: zarr/%(version)s-zarr.css
   contents:
     - css/zarr_palette.css

--- a/ckanext/zarr/assets/webassets.yml
+++ b/ckanext/zarr/assets/webassets.yml
@@ -2,6 +2,10 @@ zarr-theme:
   output: zarr/%(version)s-zarr.css
   contents:
     - css/zarr.css
+
+zarr-theme-palette:
+  output: zarr/%(version)s-zarr-palette.css
+  contents:
     - css/zarr_palette.css
 
 FileInputComponentStyles:

--- a/ckanext/zarr/assets/webassets.yml
+++ b/ckanext/zarr/assets/webassets.yml
@@ -1,20 +1,20 @@
 zarr-theme:
-  output: zarr/%(version)s-zarr.css
+  output: zarr/zarr.css
   contents:
     - css/zarr.css
 
 zarr-theme-palette:
-  output: zarr/%(version)s-zarr.css
+  output: zarr/zarr.css
   contents:
     - css/zarr_palette.css
 
 FileInputComponentStyles:
     contents:
         - css/FileInputComponent.css
-    output: zarr/%(version)s_FileInputComponent.css
+    output: zarr/FileInputComponent.css
 
 FileInputComponentScripts:
     contents:
         - frictionless-js.js
         - build/FileInputComponent.js
-    output: zarr/%(version)s_FileInputComponent.js
+    output: zarr/FileInputComponent.js

--- a/ckanext/zarr/assets/webassets.yml
+++ b/ckanext/zarr/assets/webassets.yml
@@ -2,10 +2,6 @@ zarr-theme:
   output: zarr/%(version)s-zarr.css
   contents:
     - css/zarr.css
-
-zarr-theme-palette:
-  output: zarr/%(version)s-zarr.css
-  contents:
     - css/zarr_palette.css
 
 FileInputComponentStyles:

--- a/ckanext/zarr/assets/webassets.yml
+++ b/ckanext/zarr/assets/webassets.yml
@@ -1,20 +1,20 @@
 zarr-theme:
-  output: zarr/zarr.css
+  output: zarr/%(version)s-zarr.css
   contents:
     - css/zarr.css
 
 zarr-theme-palette:
-  output: zarr/zarr.css
+  output: zarr/%(version)s-zarr.css
   contents:
     - css/zarr_palette.css
 
 FileInputComponentStyles:
     contents:
         - css/FileInputComponent.css
-    output: zarr/FileInputComponent.css
+    output: zarr/%(version)s_FileInputComponent.css
 
 FileInputComponentScripts:
     contents:
         - frictionless-js.js
         - build/FileInputComponent.js
-    output: zarr/FileInputComponent.js
+    output: zarr/%(version)s_FileInputComponent.js


### PR DESCRIPTION
## Description

We had trouble with the deployment, we kept see errors coming through that said:

`webassets.exceptions.BundleError: Cannot find version of <Bundle output=zarr/%(version)s-zarr.css, filters=(), contents=('css/zarr.css',)>. There is no manifest which knows the version, and it cannot be determined dynamically, because: output target has a placeholder.`

Turns out we accidentally named all our web assets with the same name.

@A-Souhei - did we want each asset separately (as per this PR) or bundled?

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
