### PR TITLE
Duplicate "Licence Licence not specified" in resource read

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -350,3 +350,10 @@
     background-color: var(--primary10);
 }
 /* misc */
+.licence-space {
+    padding-top: 3px;
+    padding-left: 15px;
+    padding-right: 15px;
+    margin: 0;
+    font-size: 14px;
+}

--- a/ckanext/zarr/templates/package/resource_read.html
+++ b/ckanext/zarr/templates/package/resource_read.html
@@ -1,0 +1,13 @@
+{%  ckan_extends %}
+
+{% block secondary_content %}
+
+  {% block resources_list %}
+    {% snippet "package/snippets/resources.html", pkg=pkg, active=res.id, action='read' %}
+  {% endblock %}
+
+  <tr>
+    <th scope="row"></th>
+      <td><p class="licence-space">{{ _('License') }}{% snippet "snippets/resource_license.html", pkg_dict=pkg, text_only=True %}</p></td>
+  </tr>
+{% endblock %}

--- a/ckanext/zarr/templates/snippets/resource_license.html
+++ b/ckanext/zarr/templates/snippets/resource_license.html
@@ -1,0 +1,16 @@
+{%  extends 'snippets/license.html' %}
+
+{% block license %}
+  {% if text_only %}
+      {% set text_license = license_string(pkg_dict) | trim %}
+      {% if 'License not specified' in text_license %}
+          {{ 'not specified' }}
+      {%  else %}
+        {{ text_license }}
+      {% endif %}
+  {% else %}
+      {% block license_wrapper %}
+        {{ super() }}
+      {% endblock %}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Description

This PR attempts to remove the 'License' in 'License not specified' when dataset has this selected as license.

Also adds a bit of styling for the license paragraph.

![image](https://github.com/user-attachments/assets/3575cb54-cfbe-4d0a-b04d-fab31658975b)

Might be possible to change the option value but I would need to dig deeper.

Closes https://github.com/fjelltopp/zarr-ckan/issues/152

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
