### PR TITLE
170 - Login to Log in

### DIFF
--- a/ckanext/zarr/templates/user/login.html
+++ b/ckanext/zarr/templates/user/login.html
@@ -1,0 +1,17 @@
+{%  ckan_extends %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Log in'), named_route='user.login') }}</li>
+{% endblock %}
+
+
+{% block primary_content %}
+  <section class="module">
+    <div class="module-content">
+      <h1 class="page-heading">{% block page_heading %}{{ _('Log in') }}{% endblock %}</h1>
+      {% block form %}
+        {% snippet "user/snippets/login_form.html", error_summary=error_summary %}
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}

--- a/ckanext/zarr/templates/user/snippets/login_form.html
+++ b/ckanext/zarr/templates/user/snippets/login_form.html
@@ -1,0 +1,5 @@
+{%  ckan_extends %}
+
+    {% block login_button %}
+    <button class="btn btn-primary" type="submit">{{ _('Log in') }}</button>
+    {% endblock %}


### PR DESCRIPTION
## Description

Any "Login " in login page is now "Log in"

![image](https://github.com/user-attachments/assets/d3b06fcc-f593-49a9-991a-60462e4a85db)

Closes https://github.com/fjelltopp/zarr-ckan/issues/170

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
