### PR TITLE
"Add Dataset" is not used in dashboard_datasets

### DIFF
--- a/ckanext/zarr/templates/user/dashboard_datasets.html
+++ b/ckanext/zarr/templates/user/dashboard_datasets.html
@@ -1,0 +1,13 @@
+{%  ckan_extends %}
+
+{% block page_primary_action %}
+    <h2 class="page-heading mb-4">
+    {% if not user_dict.datasets %}
+        <small class="text-muted fs-5">{{ _("You haven’t created any datasets")}}</small>
+        {% if h.check_access('package_create') %}
+            {% link_for _('Add Dataset'), named_route='dataset.new', class_="btn btn-primary dashboard-add-dataset-btn" %}
+        {% endif %}
+    {% endif %}
+
+    </h2>
+{% endblock %}


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/150270c0-8232-4efc-b224-2939f8ee37ef)


We use "Create new dataset" on the "My account" page but "Add Dataset" on the "Find Data" page, let's use "Add Dataset" for both.

Closes https://github.com/fjelltopp/zarr-ckan/issues/171

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
