### PR TITLE
172 - "My account" should be "My Account"

### DIFF
--- a/ckanext/zarr/templates/header.html
+++ b/ckanext/zarr/templates/header.html
@@ -25,3 +25,11 @@
          ) }}
 {% endblock %}
 
+
+{%  block my_account %}
+    {% set path_is_activity = request.path == '/dashboard/' %}
+    <li class="{% if user_dict.name == g.userobj.name %}{% if path_is_activity %}active{% endif %} my_account{% endif %}">
+        <a href="{{ h.url_for('activity.dashboard') }}">{{ _('My Account') }}</a>
+    </li>
+{% endblock %}
+


### PR DESCRIPTION
## Description
Only updates "My account" to "My Account" in top navbar.

Note that there are other instances of "My account" in:
- footer
- dashboard breadcrumbs including sysadmin
Shall I update all of them?

![image](https://github.com/user-attachments/assets/56ef0398-f492-4c7e-bf97-2d899724fb10)


Closes https://github.com/fjelltopp/zarr-ckan/issues/172

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
