### PR TITLE
feat: make group icons on homepage show their group images as icons

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -115,6 +115,7 @@
     margin-right: 26px;
     margin-bottom: 6px;
     border-radius: 4px;
+    text-align: center;
 }
 
 .topics li a .topic-link {

--- a/ckanext/zarr/assets/css/zarr_palette.css
+++ b/ckanext/zarr/assets/css/zarr_palette.css
@@ -63,7 +63,7 @@
     pointer-events: none;
 }
 .flag-bar {
-    width: 60px;
+    width: 30px;
     height: 100%;
 }
 .flag-black {

--- a/ckanext/zarr/templates/group/snippets/group_item.html
+++ b/ckanext/zarr/templates/group/snippets/group_item.html
@@ -5,5 +5,5 @@
 {% set url = h.url_for(type ~ '.read', id=group.name) %}
 
 {% block item %}
-    <li><a href="{{ url }}"><p class="topic-top-square"></p><p class="topic-link">{{ _(group.title) }}</p></a></li>
+    <li><a href="{{ url }}"><p class="topic-top-square"><img src="{{ group.image_url }}" width="36px"/></p><p class="topic-link">{{ _(group.title) }}</p></a></li>
 {% endblock %}


### PR DESCRIPTION
## Description

We wanted the icons on the homepage that show the different resource types to be more visual. I have given each group and `image_url` and that is now rendered inside the little box.

Also, I made the flag a little thinner.

The `zarr-ckan` PR includes updated demo data loader for these icons.

relates fjelltopp/zarr-ckan#
relates (but is not dependent on) fjelltopp/ckanext-fjelltopp-theme#31

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
