### PR TITLE
185 - Fjelltopp theme leaks through on the footer

### DIFF
--- a/ckanext/zarr/templates/page.html
+++ b/ckanext/zarr/templates/page.html
@@ -2,6 +2,7 @@
 
 {% block fx_bg %}{% endblock %}
 {% block footer_fx_bg %}{% endblock %}
+{% block footer_fx_container %}{% endblock %}
 
 {% block fx_container %}
 <div class="flag-vertical-bars">

--- a/ckanext/zarr/templates/page.html
+++ b/ckanext/zarr/templates/page.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
 
 {% block fx_bg %}{% endblock %}
+{% block footer_fx_bg %}{% endblock %}
 
 {% block fx_container %}
 <div class="flag-vertical-bars">


### PR DESCRIPTION
## Description

This removes the circle fx from fjelltopp-theme (from footer).

![image](https://github.com/user-attachments/assets/08e3966b-ae79-4f1d-ac76-b80187b186e3)

Relates https://github.com/fjelltopp/ckanext-fjelltopp-theme/pull/32
Closes https://github.com/fjelltopp/zarr-ckan/issues/185



## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
