### PR TITLE
191 - Make schema metadata and groups work together

### DIFF
--- a/ckanext/zarr/actions.py
+++ b/ckanext/zarr/actions.py
@@ -181,3 +181,20 @@ def _record_dataset_duplication(dataset_id, new_dataset_id, context):
         log.exception(e)
 
 
+def add_dataset_to_resource_type_group(resource_type, dataset_id):
+    groups_list = toolkit.get_action('group_list')({})
+    if resource_type in groups_list:
+        try:
+            toolkit.get_action('member_create')(
+                data_dict={
+                    'id': resource_type,
+                    'object': dataset_id,
+                    'object_type': 'package',
+                    'capacity': 'public'
+                }
+            )
+        except Exception as e:
+            log.error(f"Failed to add dataset {dataset_id} to group {resource_type}")
+            log.exception(e)
+    else:
+        log.warning(f"Group {resource_type} does not exist. Dataset {dataset_id} not added to any group.")

--- a/ckanext/zarr/plugin.py
+++ b/ckanext/zarr/plugin.py
@@ -91,7 +91,13 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     def after_dataset_update(self, context, data_dict):
         if data_dict.get('private'):
             zarr_upload.add_activity(context, data_dict, "changed")
+        resource_type = data_dict.get('resource_type')
+        if resource_type:
+            zarr_actions.add_dataset_to_resource_type_group(resource_type, data_dict['id'])
 
     def after_dataset_create(self, context, data_dict):
         if data_dict.get('private'):
             zarr_upload.add_activity(context, data_dict, "new")
+        resource_type = data_dict.get('resource_type')
+        if resource_type:
+            zarr_actions.add_dataset_to_resource_type_group(resource_type, data_dict['id'])


### PR DESCRIPTION
## Description

When "resource type" group exists and an option of the metadata has been selected during dataset create or update, the dataset will be added to the group.

Updating the resource type will add the dataset to the selected resource type ie it will be member of previously selected resource type and the last one selected. @ChasNelson1990 is that the correct behavior or should I remove it from old group and add to newly selected?

![image](https://github.com/user-attachments/assets/4cb6e473-7e8c-4bd7-971d-69e934430bfd)

Closes https://github.com/fjelltopp/zarr-ckan/issues/191


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
