### PR TITLE
195 - On wide screens the dark green doesn't cover the full photo on the home page

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -12,7 +12,7 @@
     width: calc(100% - 72px);
     height: 100%;
     background: url("/images/zarr_bg_transparent_layer.png") no-repeat center center;
-    background-size: auto 100%;
+    background-size: cover;
     pointer-events: none;
     z-index: 1;
 }


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/5d9321e9-c35e-4e66-9ffb-825301b0eaaa)
Closes https://github.com/fjelltopp/zarr-ckan/issues/195

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
