### PR TITLE
204 - Remove badge from home recently updated datasets

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -376,3 +376,7 @@
     text-align: inherit;
     float: right;
 }
+
+.recently-updated .dataset-content .dataset-heading span.badge {
+    display: none;
+}


### PR DESCRIPTION
## Description

This PR brings back to the former design of home recently updated datasets blocks. Because of the badges that has been fixed in the package_item templates they are currently showing, ie pic below:

![image](https://github.com/user-attachments/assets/4513081e-9c4b-4bf7-912c-3ed43fe4976a)

With this commit, we get:

![image](https://github.com/user-attachments/assets/71fd915f-19f2-4272-b095-88cc551622dc)

Closes https://github.com/fjelltopp/zarr-ckan/issues/204

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
