### PR TITLE
200 -  Unable to delete draft dataset after adding it

### DIFF
--- a/ckanext/zarr/templates/package/new_package_form.html
+++ b/ckanext/zarr/templates/package/new_package_form.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{% block delete_button %}
+    {% if form_style == 'edit' and h.check_access('package_delete', {'id': pkg_dict.id}) %}
+        {{ super() }}
+    {% elif data.state == 'draft' %}
+        {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
+          <a class="btn btn-danger pull-left" href="{% url_for dataset_type ~ '.delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ h.humanize_entity_type('package', dataset_type, 'delete confirmation') or _('Are you sure you want to delete this dataset?') }}">
+              {{ _('Delete draft') }}
+          </a>
+        {% endif %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Description

Draft datasets can now be deleted upon creation or when returning to previous URL in history. Upon deletion, dataset name, url are available again.

**Possible improvements:** add a package list page to show leftover drafts @ChasNelson1990 ?

![image](https://github.com/user-attachments/assets/847cb8ec-5b44-4e21-8372-d86591e60b1f)
![image](https://github.com/user-attachments/assets/986891fc-b323-43ae-aa7d-0c011468fb8e)
![image](https://github.com/user-attachments/assets/af95524b-47fb-4952-bd2e-f935cd635455)

Closes https://github.com/fjelltopp/zarr-ckan/issues/200

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
