### PR TITLE
196 email addresses are case sensitive

### DIFF
--- a/ckanext/zarr/plugin.py
+++ b/ckanext/zarr/plugin.py
@@ -9,7 +9,6 @@ import ckanext.zarr.upload as zarr_upload
 import ckanext.zarr.validators as zarr_validators
 import ckanext.zarr.helpers as zarr_helpers
 from ckan.lib.plugins import DefaultPermissionLabels
-from flask import request, g
 import ckan.model as model
 from sqlalchemy import func
 

--- a/ckanext/zarr/plugin.py
+++ b/ckanext/zarr/plugin.py
@@ -16,7 +16,7 @@ from sqlalchemy import func
 log = logging.getLogger(__name__)
 
 
-class WHOAFROPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
+class ZaRRPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
 
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IFacets, inherit=True)

--- a/ckanext/zarr/plugin.py
+++ b/ckanext/zarr/plugin.py
@@ -13,7 +13,6 @@ from flask import request, g
 import ckan.model as model
 from sqlalchemy import func
 
-from ckanext.zarr.helpers import lower_formatter
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/zarr/plugin.py
+++ b/ckanext/zarr/plugin.py
@@ -111,15 +111,17 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         """
         verify is email is used | different case
         """
-        if not identity or not identity.get('login'):
+        if not identity or not identity.get('login') or not identity.get('password'):
             return None
         login = identity.get('login')
+        password = identity.get('password')
         query = model.Session.query(model.User).filter(
             func.lower(model.User.email) == func.lower(login)
         )
         user = query.first()
         if user and user.is_active:
-            return user
+            if user.validate_password(password):
+                return user
         return None
 
     def identify(self):

--- a/ckanext/zarr/tests/test_authentication.py
+++ b/ckanext/zarr/tests/test_authentication.py
@@ -52,6 +52,19 @@ class TestAuthentication:
         authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
         assert authenticated_user is None
 
+    def test_wrong_password_with_different_case_email(self):
+        """Test authentication fails with incorrect password and different case email"""
+        factories.User(
+            email='test@example.com',
+            password='correctpassword'
+        )
+        identity = {
+            'login': 'Test@Example.com',
+            'password': 'wrongpassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is None
+
     def test_nonexistent_user(self):
         """Test authentication fails for non-existent user"""
         identity = {

--- a/ckanext/zarr/tests/test_authentication.py
+++ b/ckanext/zarr/tests/test_authentication.py
@@ -1,7 +1,7 @@
 import pytest
 from ckan.tests import factories
 import ckan.model as model
-from ckanext.zarr.plugin import WHOAFROPlugin as ZaRRPlugin
+from ckanext.zarr.plugin import ZaRRPlugin
 
 
 @pytest.mark.ckan_config('ckan.plugins', "zarr")

--- a/ckanext/zarr/tests/test_authentication.py
+++ b/ckanext/zarr/tests/test_authentication.py
@@ -1,0 +1,108 @@
+import pytest
+from ckan.tests import factories
+import ckan.model as model
+from ckanext.zarr.plugin import WHOAFROPlugin as ZaRRPlugin
+
+
+@pytest.mark.ckan_config('ckan.plugins', "zarr")
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
+class TestAuthentication:
+    def test_successful_authentication_with_email(self):
+        """Test successful authentication using email and correct password"""
+        user = factories.User(
+            email='test@example.com',
+            password='correctpassword'
+        )
+        identity = {
+            'login': 'test@example.com',
+            'password': 'correctpassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is not None
+        assert authenticated_user.id == user['id']
+        assert authenticated_user.is_active
+
+    def test_case_insensitive_email(self):
+        """Test that email authentication is case-insensitive"""
+        user = factories.User(
+            email='Test@Example.com',
+            password='correctpassword'
+        )
+        # Try with lowercase email
+        identity = {
+            'login': 'test@example.com',
+            'password': 'correctpassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+
+        assert authenticated_user is not None
+        assert authenticated_user.id == user['id']
+        assert authenticated_user.is_active
+
+    def test_wrong_password(self):
+        """Test authentication fails with incorrect password"""
+        factories.User(
+            email='test@example.com',
+            password='correctpassword'
+        )
+        identity = {
+            'login': 'test@example.com',
+            'password': 'wrongpassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is None
+
+    def test_nonexistent_user(self):
+        """Test authentication fails for non-existent user"""
+        identity = {
+            'login': 'nonexistent@example.com',
+            'password': 'anypassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is None
+
+    def test_inactive_user(self):
+        """Test authentication fails for inactive user"""
+        user = factories.User(
+            email='test@example.com',
+            password='correctpassword'
+        )
+        # Deactivate user
+        user_obj = model.User.get(user['id'])
+        user_obj.state = 'inactive'
+        model.Session.commit()
+        identity = {
+            'login': 'test@example.com',
+            'password': 'correctpassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is None
+
+    def test_empty_identity(self):
+        """Test authentication fails with empty identity"""
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), None)
+        assert authenticated_user is None
+
+    def test_missing_password(self):
+        """Test authentication fails with missing password"""
+        factories.User(
+            email='test@example.com',
+            password='correctpassword'
+        )
+        identity = {
+            'login': 'test@example.com'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is None
+
+    def test_missing_login(self):
+        """Test authentication fails with missing login"""
+        factories.User(
+            email='test@example.com',
+            password='correctpassword'
+        )
+        identity = {
+            'password': 'correctpassword'
+        }
+        authenticated_user = ZaRRPlugin.authenticate(ZaRRPlugin(), identity)
+        assert authenticated_user is None

--- a/ckanext/zarr/tests/test_plugin.py
+++ b/ckanext/zarr/tests/test_plugin.py
@@ -2,7 +2,7 @@ import pytest
 
 from ckan.tests import factories
 from ckan.tests.helpers import call_action
-from ckanext.zarr.plugin import WHOAFROPlugin
+from ckanext.zarr.plugin import ZaRRPlugin
 from ckanext.zarr.tests import get_context
 
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points='''
         [ckan.plugins]
-        zarr=ckanext.zarr.plugin:WHOAFROPlugin
+        zarr=ckanext.zarr.plugin:ZaRRPlugin
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
## Description

Using the interface `IAuthenticator` to verify if an email should be accepted (in case the case is different from the one registered in database)

In this PR:

-  added authenticate() from interface plugins.implements(plugins.IAuthenticator)
- added tests for authenticate()
- [Renamed WHOAFROPlugin to ZaRRPlugin](https://github.com/fjelltopp/ckanext-zarr/pull/55/commits/c9c0e1638c698b1d42243bce3021ee840422c6d2)
- added a .env in zarr-ckan

Relates https://github.com/fjelltopp/zarr-ckan/pull/215
Closes https://github.com/fjelltopp/zarr-ckan/issues/196


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
