### PR TITLE
Coloured stripes block other UI elements on small devices

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -376,3 +376,7 @@
     text-align: inherit;
     float: right;
 }
+
+ul.nav.nav-tabs {
+    z-index: 9;
+}


### PR DESCRIPTION
## Description

Fix nav tabs getting overlapped by the promoted vertical bars at right.

![image](https://github.com/user-attachments/assets/51def1d9-d068-4f11-b613-a0adb0b9bda0)


Closes https://github.com/fjelltopp/zarr-ckan/issues/222

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
