### PR TITLE
Some metadata fields are not responsive when viewing datasets

### DIFF
--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -380,7 +380,7 @@
 .dataset table.table.table-striped.table-bordered.table-condensed {
     tr {
         td {
-            word-wrap: break-word;
+            word-break: break-all;
         }
     }
 }

--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -378,8 +378,8 @@
 }
 
 .dataset table.table.table-striped.table-bordered.table-condensed {
-    tr {
-        td {
+    tr td {
+        dd {
             word-break: break-all;
         }
     }

--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -384,3 +384,12 @@
         }
     }
 }
+
+.dataset {
+    .promoted .description p,
+    #dataset-description p,
+    .prose.notes
+    {
+        text-align: justify;
+    }
+}

--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -380,7 +380,7 @@
 .dataset table.table.table-striped.table-bordered.table-condensed {
     tr {
         td {
-            word-break: break-all;
+            word-wrap: break-word;
         }
     }
 }

--- a/ckanext/zarr/assets/css/zarr.css
+++ b/ckanext/zarr/assets/css/zarr.css
@@ -376,3 +376,11 @@
     text-align: inherit;
     float: right;
 }
+
+.dataset table.table.table-striped.table-bordered.table-condensed {
+    tr {
+        td {
+            word-break: break-all;
+        }
+    }
+}


### PR DESCRIPTION
## Description

- added a word break property so metadata fields width adjust with container
- justified dataset and resource descriptions

![image](https://github.com/user-attachments/assets/fe8ae8bd-7165-40d9-a01d-cb2242f5e816)


Closes https://github.com/fjelltopp/zarr-ckan/issues/223

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
